### PR TITLE
Add social media links to footer

### DIFF
--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -1,3 +1,6 @@
+<!-- Line Awesome icons for social links -->
+<link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
+
 <style>
   /* Left-align all blog pages (listing and posts) */
   {{ if eq .Section "blog" }}
@@ -6,4 +9,20 @@
     margin-right: auto;
   }
   {{ end }}
+
+  /* Social links styling */
+  .social-links {
+    margin-bottom: 15px;
+  }
+
+  .social-links a {
+    color: var(--text-color);
+    margin: 0 10px;
+    transition: color 0.2s ease;
+  }
+
+  .social-links a:hover {
+    color: var(--link-color);
+    text-decoration: none;
+  }
 </style>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,10 @@
+{{ if .Site.Params.social }}
+<div class="social-links">
+  {{ range .Site.Params.social }}
+  <a href="{{ .url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ .name }}">
+    <i class="{{ .icon }}"></i>
+  </a>
+  {{ end }}
+</div>
+{{ end }}
+{{ if ne .Site.Params.hideMadeWithLine true }}Made with <a href="https://github.com/janraasch/hugo-bearblog/">Hugo ʕ•ᴥ•ʔ Bear</a>{{ end }}


### PR DESCRIPTION
- Create custom footer partial to display social icons from config
- Add Line Awesome icon library for social media icons
- Style social links with hover effects matching theme colors
- Social links (GitHub, LinkedIn, Twitter) now appear in footer